### PR TITLE
Prevent reading one byte out of bounds in parse_urlencoded(_arrayref)

### DIFF
--- a/lib/WWW/Form/UrlEncoded/XS.xs
+++ b/lib/WWW/Form/UrlEncoded/XS.xs
@@ -221,9 +221,11 @@ parse_urlencoded(qs)
             mPUSHs(url_decode(aTHX_ src, p - prev + prev_s + f, i ));
         }
 
-        if ( src[src_len-1] == '&' || src[src_len-1] == ';' ) {
-            mPUSHs(newSVpv("",0));
-            mPUSHs(newSVpv("",0));
+        if ( src_len > 0 ) {
+            if ( src[src_len-1] == '&' || src[src_len-1] == ';' ) {
+                mPUSHs(newSVpv("",0));
+                mPUSHs(newSVpv("",0));
+            }
         }
 
     }
@@ -280,9 +282,11 @@ parse_urlencoded_arrayref(qs)
             av_push(av, url_decode(aTHX_ src, p - prev + prev_s + f, i ));
         }
 
-        if ( src[src_len-1] == '&' || src[src_len-1] == ';' ) {
-            av_push(av, newSVpv("",0));
-            av_push(av,newSVpv("",0));
+        if ( src_len > 0 ) {
+            if ( src[src_len-1] == '&' || src[src_len-1] == ';' ) {
+                av_push(av, newSVpv("",0));
+                av_push(av,newSVpv("",0));
+            }
         }
     }
     XSRETURN(1);


### PR DESCRIPTION
At work we were seeing segfaults coming from this code.

On a perl compiled with `-fsanitize=address`, running the test suite revealed this:
```
t/03_parse_arrayref.t .. 1/? =================================================================
==27712== ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6004000c0e0f at pc 0x7fde982778e9 bp 0x7ffd2bdc82f0 sp 0x7ffd2bdc82e0
READ of size 1 at 0x6004000c0e0f thread T0
    #0 0x7fde982778e8 (/usr/local/git_tree/WWW-Form-UrlEncoded-XS/blib/arch/auto/WWW/Form/UrlEncoded/XS/XS.so+0x28e8)
    #1 0x6b5dc8 (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x6b5dc8)
    #2 0x619101 (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x619101)
    #3 0x4b211b (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x4b211b)
    #4 0x42ce10 (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x42ce10)
    #5 0x7fde9f98c554 (/usr/lib64/libc-2.17.so+0x22554)
    #6 0x42d35d (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x42d35d)
0x6004000c0e0f is located 1 bytes to the left of 10-byte region [0x6004000c0e10,0x6004000c0e1a)
allocated by thread T0 here:
    #0 0x7fdea0ac4119 (/usr/lib64/libasan.so.0.0.0+0x16119)
    #1 0x630650 (/home/hugmeir/perl5/perlbrew/perls/perl-5.28.3/bin/perl+0x630650)
Shadow bytes around the buggy address:
  0x0c0100010170: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0100010180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0100010190: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c01000101a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c01000101b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c01000101c0: fa[fa]00 02 fa fa 00 02 fa fa 00 02 fa fa 00 02
  0x0c01000101d0: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c01000101e0: fa fa fd fd fa fa fd fd fa fa 00 02 fa fa fd fd
  0x0c01000101f0: fa fa fd fd fa fa fd fd fa fa 00 02 fa fa fd fd
  0x0c0100010200: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c0100010210: fa fa fd fd fa fa 00 02 fa fa fd fd fa fa fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:     fa
  Heap righ redzone:     fb
  Freed Heap region:     fd
  Stack left redzone:    f1
  Stack mid redzone:     f2
  Stack right redzone:   f3
  Stack partial redzone: f4
  Stack after return:    f5
  Stack use after scope: f8
  Global redzone:        f9
  Global init order:     f6
  Poisoned by user:      f7
  ASan internal:         fe
==27712== ABORTING
t/03_parse_arrayref.t .. Dubious, test returned 1 (wstat 256, 0x100)
All 20 subtests passed
```

which ended up being reproducible with just this one-liner:
```
; perl Build.PL; perl Build; perl -Mblib -E 'use WWW::Form::UrlEncoded::XS qw(parse_urlencoded_arrayref); say parse_urlencoded_arrayref("")'
```

Admittedly we haven't been able to actually reproduce the original segfault in a controlled environment, but presumably this is the culprit.